### PR TITLE
Apply minor refactoring to fuse intermediate passes

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -55,7 +55,7 @@ pub async fn assume_role(
     assume_role_exec(account, role, mfa_id, mfa_token, &client).await
 }
 
-pub fn get_region(preselect: &Option<String>) -> Result<Region> {
+pub fn get_region(preselect: Option<&str>) -> Result<Region> {
     if let Some(region) = preselect {
         let region = Region::from_str(region)?;
         Ok(region)
@@ -70,21 +70,15 @@ mod tests {
 
     #[test]
     fn region_from_string() {
-        assert_eq!(
-            get_region(&Some(String::from("EuCentral1"))).unwrap(),
-            Region::EuCentral1
-        );
-        assert_eq!(
-            get_region(&Some(String::from("UsEast1"))).unwrap(),
-            Region::UsEast1
-        );
-        assert_eq!(get_region(&None).unwrap(), Region::default());
+        assert_eq!(get_region(Some("EuCentral1")).unwrap(), Region::EuCentral1);
+        assert_eq!(get_region(Some("UsEast1")).unwrap(), Region::UsEast1);
+        assert_eq!(get_region(None).unwrap(), Region::default());
     }
 
     #[test]
     fn region_error_fallback() {
-        assert!(get_region(&Some(String::from(""))).is_err());
-        assert!(get_region(&Some(String::from("foobar"))).is_err());
+        assert!(get_region(Some("")).is_err());
+        assert!(get_region(Some("foobar")).is_err());
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,12 +14,12 @@ pub struct Account {
 }
 
 fn parse_json(contents: &str) -> Result<Vec<Account>> {
-    let acc: Vec<Account> = serde_json::from_str(&contents)?;
+    let acc: Vec<Account> = serde_json::from_str(contents)?;
     Ok(acc)
 }
 
 pub fn read(path: &Path) -> Result<Vec<Account>> {
-    let contents = util::read_file(&path)?;
+    let contents = util::read_file(path)?;
     let res = parse_json(&contents)?;
     Ok(res)
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -15,8 +15,7 @@ fn parse_json(contents: &str) -> Option<History> {
 }
 
 pub fn read(path: &Path) -> Option<History> {
-    let contents = util::read_file(path).ok();
-    contents.and_then(|c| parse_json(&c))
+    util::read_file(path).ok().as_deref().and_then(parse_json)
 }
 
 pub fn write(path: &Path, history: &History) -> Result<()> {

--- a/src/history.rs
+++ b/src/history.rs
@@ -16,7 +16,7 @@ fn parse_json(contents: &str) -> Option<History> {
 
 pub fn read(path: &Path) -> Option<History> {
     let contents = util::read_file(path).ok();
-    contents.map(|c| parse_json(&c)).flatten()
+    contents.and_then(|c| parse_json(&c))
 }
 
 pub fn write(path: &Path, history: &History) -> Result<()> {

--- a/src/history.rs
+++ b/src/history.rs
@@ -11,11 +11,11 @@ pub struct History {
 }
 
 fn parse_json(contents: &str) -> Option<History> {
-    serde_json::from_str(&contents).ok()
+    serde_json::from_str(contents).ok()
 }
 
 pub fn read(path: &Path) -> Option<History> {
-    let contents = util::read_file(&path).ok();
+    let contents = util::read_file(path).ok();
     contents.map(|c| parse_json(&c)).flatten()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ async fn main() {
     };
 
     let status = match &arguments.exec {
-        Some(exec) => set_credentials_and_exec(&credentials, &exec),
+        Some(exec) => set_credentials_and_exec(&credentials, exec),
         None => print_credentials(&shell, &credentials),
     };
     if status.is_err() {
@@ -165,7 +165,7 @@ fn set_credentials(credentials: &Credentials) -> Result<()> {
 }
 
 fn print_credentials(shell: &Shell, credentials: &Credentials) -> Result<()> {
-    match shell::export_string(&shell, aws::ACCESS_KEY_ID, &credentials.access_key_id) {
+    match shell::export_string(shell, aws::ACCESS_KEY_ID, &credentials.access_key_id) {
         Ok(set_env) => println!("{}", set_env),
         Err(err) => {
             error!("Could not set env '{}': {}", aws::ACCESS_KEY_ID, err);
@@ -173,7 +173,7 @@ fn print_credentials(shell: &Shell, credentials: &Credentials) -> Result<()> {
         }
     }
     match shell::export_string(
-        &shell,
+        shell,
         aws::SECRET_ACCESS_KEY,
         &credentials.secret_access_key,
     ) {
@@ -183,7 +183,7 @@ fn print_credentials(shell: &Shell, credentials: &Credentials) -> Result<()> {
             return Err(err);
         }
     }
-    match shell::export_string(&shell, aws::SESSION_TOKEN, &credentials.session_token) {
+    match shell::export_string(shell, aws::SESSION_TOKEN, &credentials.session_token) {
         Ok(set_env) => println!("{}", set_env),
         Err(err) => {
             error!("Could not set env '{}': {}", aws::SESSION_TOKEN, err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,15 +102,9 @@ fn select_account(arguments: &Arguments, history: &Option<History>) -> Result<Op
     let mut accounts = config::read(&arguments.get_config_path())?;
     match &arguments.account {
         Some(account_id) => {
-            let account = accounts
-                .iter()
-                .filter(|&a| &a.id == account_id)
-                .cloned()
-                .collect::<Vec<Account>>()
-                .first()
-                .cloned();
+            let account = accounts.iter().find(|a| &a.id == account_id);
             match account {
-                Some(account) => Ok(Some(account)),
+                Some(account) => Ok(Some(account.clone())),
                 None => bail!("Account {} not found in config.", account_id),
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn main() {
     debug!("Shell: {:?}", &shell);
     let history = history::read(&arguments.get_history_path());
     debug!("History: {:?}", &history);
-    let region = match aws::get_region(&arguments.region) {
+    let region = match aws::get_region(arguments.region.as_deref()) {
         Ok(region) => region,
         Err(err) => {
             error!("{}", err);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -19,7 +19,7 @@ impl Default for Shell {
 }
 
 impl FromStr for Shell {
-    type Err = ();
+    type Err = std::convert::Infallible;
 
     fn from_str(shell: &str) -> Result<Self, Self::Err> {
         if shell == "fish" {

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -26,7 +26,7 @@ fn get_account_names(accounts: &[Account]) -> Vec<String> {
 
 fn sort_with_preselect<T: Clone>(
     list: &[T],
-    preselect: &Option<String>,
+    preselect: Option<&str>,
     finder: &dyn Fn(&[T], &str) -> Option<usize>,
 ) -> Vec<T> {
     if let Some(element) = preselect {
@@ -40,7 +40,7 @@ fn sort_with_preselect<T: Clone>(
     list.to_owned()
 }
 
-pub fn select_account(accounts: Vec<Account>, preselect: &Option<String>) -> Option<Account> {
+pub fn select_account(accounts: Vec<Account>, preselect: Option<&str>) -> Option<Account> {
     fn finder(list: &[Account], p: &str) -> Option<usize> {
         list.iter().position(|a| a.id == p)
     }
@@ -65,7 +65,7 @@ fn get_account_from_sorted_names(
     })
 }
 
-pub fn select_role(roles: Vec<Role>, preselect: &Option<String>) -> Option<Role> {
+pub fn select_role(roles: Vec<Role>, preselect: Option<&str>) -> Option<Role> {
     fn finder(list: &[String], p: &str) -> Option<usize> {
         list.iter().position(|a| a == p)
     }
@@ -112,11 +112,8 @@ mod tests {
             String::from("bar"),
             String::from("baz"),
         ];
-        assert_eq!(sort_with_preselect(&list, &None, &finder), list);
-        assert_eq!(
-            sort_with_preselect(&list, &Some(String::from("nope")), &finder),
-            list
-        );
+        assert_eq!(sort_with_preselect(&list, None, &finder), list);
+        assert_eq!(sort_with_preselect(&list, Some("nope"), &finder), list);
 
         let sorted_list = vec![
             String::from("baz"),
@@ -124,7 +121,7 @@ mod tests {
             String::from("bar"),
         ];
         assert_eq!(
-            sort_with_preselect(&list, &Some(String::from("baz")), &finder),
+            sort_with_preselect(&list, Some("baz"), &finder),
             sorted_list
         );
     }
@@ -160,7 +157,7 @@ mod tests {
         fn finder(list: &[Account], p: &str) -> Option<usize> {
             list.iter().position(|a| a.id == p)
         }
-        let sorted = sort_with_preselect(&accounts, &Some(String::from("2")), &finder);
+        let sorted = sort_with_preselect(&accounts, Some("2"), &finder);
         let account_names = get_account_names(&sorted);
         assert_eq!(
             get_account_from_sorted_names(accounts.clone(), account_names.clone(), &Some(0)),

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -45,7 +45,7 @@ pub fn select_account(accounts: Vec<Account>, preselect: Option<&str>) -> Option
     }
     let accounts = sort_with_preselect(&accounts, preselect, &finder);
     let account_names = get_account_names(&accounts);
-    let pos = get_selection(&String::from("Accounts:"), &account_names);
+    let pos = get_selection("Accounts:", &account_names);
     get_account_from_sorted_names(accounts, account_names, &pos)
 }
 
@@ -69,7 +69,7 @@ pub fn select_role(roles: Vec<Role>, preselect: Option<&str>) -> Option<Role> {
         list.iter().position(|a| a == p)
     }
     let mut roles = sort_with_preselect(&roles, preselect, &finder);
-    get_selection(&String::from("Roles:"), &roles).map(|r| roles.remove(r))
+    get_selection("Roles:", &roles).map(|r| roles.remove(r))
 }
 
 #[cfg(test)]

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -5,7 +5,7 @@ use std::io::Cursor;
 
 fn get_selection(header: &str, options: &[String]) -> Option<usize> {
     let skim_options = SkimOptionsBuilder::default()
-        .header(Some(&header))
+        .header(Some(header))
         .build()
         .unwrap();
 

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -29,15 +29,14 @@ fn sort_with_preselect<T: Clone>(
     preselect: Option<&str>,
     finder: &dyn Fn(&[T], &str) -> Option<usize>,
 ) -> Vec<T> {
-    if let Some(element) = preselect {
-        if let Some(pos) = finder(list, element) {
-            let mut list = list.to_vec();
-            let x = list.remove(pos);
-            list.insert(0, x);
-            return list;
-        }
+    if let Some(pos) = preselect.and_then(|el| finder(list, el)) {
+        let mut list = list.to_vec();
+        let x = list.remove(pos);
+        list.insert(0, x);
+        list
+    } else {
+        list.to_owned()
     }
-    list.to_owned()
 }
 
 pub fn select_account(accounts: Vec<Account>, preselect: Option<&str>) -> Option<Account> {

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -11,13 +11,12 @@ fn get_selection(header: &str, options: &[String]) -> Option<usize> {
 
     let items = SkimItemReader::default().of_bufread(Cursor::new(options.join("\n")));
 
-    if let Some(out) = Skim::run_with(&skim_options, Some(items)) {
-        if let Event::EvActAccept(_) = out.final_event {
+    Skim::run_with(&skim_options, items.into())
+        .filter(|out| matches!(out.final_event, Event::EvActAccept(_)))
+        .and_then(|out| {
             let item = &out.selected_items[0];
-            return options.iter().position(|e| e == &item.output());
-        }
-    }
-    None
+            options.iter().position(|e| e == &item.output())
+        })
 }
 
 fn get_account_names(accounts: &[Account]) -> Vec<String> {


### PR DESCRIPTION
This PR applies a couple of minor refactoring, e.g. to avoid unnecessary references and allocations, and re-express the usage of a couple of combinators to elide intermediate iterations and/or shorten pipelines.

Hopefully, I haven't gone too far with piping to the point of obscuring the underlying logic :see_no_evil:, I'd be keen to know your thoughts.

**IMPORTANT**: Ideally, there shall be no behaviour change. However, I have _not_ had the time to test it all thoroughly yet. 